### PR TITLE
Renaming hasPermission to userHasPermission

### DIFF
--- a/src/AccessCheckerInterface.php
+++ b/src/AccessCheckerInterface.php
@@ -17,5 +17,5 @@ interface AccessCheckerInterface
      * @return bool whether the user has the specified permission.
      * @throws \InvalidArgumentException if any of argument is not of the expected type or does not refer to an existing value
      */
-    public function hasPermission($userId, string $permissionName, array $parameters = []): bool;
+    public function userHasPermission($userId, string $permissionName, array $parameters = []): bool;
 }


### PR DESCRIPTION
```php
$accessChecker->hasPermission($id, 'update', $params);
```

Now it read as `accessChecker has permission` .  May be better read as `user has permission`

```php
$accessChecker->userHasPermission($id, 'update', $params);
```

Or rewrite all to
```php
class User implements UserAccessChecker {

    public function hasPermission(string $permissionName, array $parameters = []): bool
    {

    }
}
```