### PR TITLE
Add enum support

### DIFF
--- a/src/AccessCheckerInterface.php
+++ b/src/AccessCheckerInterface.php
@@ -17,7 +17,7 @@ interface AccessCheckerInterface
      *
      * @param int|string|null $userId The user ID representing the unique identifier of a user. If ID is null,
      * it means user is a guest.
-     * @param string $permissionName The name of the permission to be checked against.
+     * @param string|\BackedEnum $permissionName The name of the permission to be checked against.
      * @param array $parameters Name-value pairs that will be used to determine if access is granted.
      *
      * @throws InvalidArgumentException If any of argument is not of the expected type or does not refer to
@@ -25,5 +25,5 @@ interface AccessCheckerInterface
      *
      * @return bool Whether the user has the specified permission.
      */
-    public function userHasPermission($userId, string $permissionName, array $parameters = []): bool;
+    public function userHasPermission($userId, $permissionName, array $parameters = []): bool;
 }

--- a/src/AccessCheckerInterface.php
+++ b/src/AccessCheckerInterface.php
@@ -17,7 +17,7 @@ interface AccessCheckerInterface
      *
      * @param int|string|null $userId The user ID representing the unique identifier of a user. If ID is null,
      * it means user is a guest.
-     * @param string|\BackedEnum $permissionName The name of the permission to be checked against.
+     * @param \BackedEnum|string $permissionName The name of the permission to be checked against.
      * @param array $parameters Name-value pairs that will be used to determine if access is granted.
      *
      * @throws InvalidArgumentException If any of argument is not of the expected type or does not refer to

--- a/src/AllowAll.php
+++ b/src/AllowAll.php
@@ -9,7 +9,7 @@ namespace Yiisoft\Access;
  */
 final class AllowAll implements AccessCheckerInterface
 {
-    public function userHasPermission($userId, string $permissionName, array $parameters = []): bool
+    public function userHasPermission($userId, $permissionName, array $parameters = []): bool
     {
         return true;
     }

--- a/src/DenyAll.php
+++ b/src/DenyAll.php
@@ -9,7 +9,7 @@ namespace Yiisoft\Access;
  */
 final class DenyAll implements AccessCheckerInterface
 {
-    public function userHasPermission($userId, string $permissionName, array $parameters = []): bool
+    public function userHasPermission($userId, $permissionName, array $parameters = []): bool
     {
         return false;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | https://github.com/yiisoft/rbac/issues/111

Since we need a string name of the permission, only `\BackedEnum` could be passed.
