### PR TITLE
Fix #18: Add missing `\Stringable` to `$userId` of `AccessCheckerInte…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Bug #18: Add missing `\Stringable` to `$userId` of `AccessCheckerInterface::userHasPermission()` (samdark)
 
 ## 1.1.0 January 14, 2022
 

--- a/src/AccessCheckerInterface.php
+++ b/src/AccessCheckerInterface.php
@@ -15,7 +15,7 @@ interface AccessCheckerInterface
     /**
      * Checks if the user with the ID given has the specified permission.
      *
-     * @param int|string|null $userId The user ID representing the unique identifier of a user. If ID is null,
+     * @param int|string|\Stringable|null $userId The user ID representing the unique identifier of a user. If ID is null,
      * it means user is a guest.
      * @param string $permissionName The name of the permission to be checked against.
      * @param array $parameters Name-value pairs that will be used to determine if access is granted.


### PR DESCRIPTION
…rface::userHasPermission()`

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #18 
